### PR TITLE
Specify what happens if no code deployed at address

### DIFF
--- a/org.aion.avm.api/src/avm/Blockchain.java
+++ b/org.aion.avm.api/src/avm/Blockchain.java
@@ -186,8 +186,8 @@ public final class Blockchain {
      * Returns the size of the code, of the given account.
      *
      * @param address the account address.
-     * @return the code size, or 0 if the account does not exist
-     * @throws IllegalArgumentException when the arguments are invalid, e.g. NULL address.
+     * @return the code size in bytes, or 0 if no contract is deployed at that address
+     * @throws IllegalArgumentException when the argument is invalid, e.g. NULL address.
      */
     public static int getCodeSize(Address address) throws IllegalArgumentException {
         return 0;


### PR DESCRIPTION
Currently it is unspecified what `codesize` will return if an address exists but it is not a contract. This adds specification for this circumstance. 